### PR TITLE
[KB-81] fix: 반응형 웹 고려

### DIFF
--- a/src/components/c-header/index.tsx
+++ b/src/components/c-header/index.tsx
@@ -30,6 +30,13 @@ export default function CHeader({ isLogo = false, isBackBtn = false, title }: Pr
 const S = {
   Wrapper: styled.div`
     padding: 20px 16px;
+    position: fixed;
+    top: 44px;
+    width: 360px;
+
+    @media screen and (max-width: 768px) {
+      width: 100%;
+    }
   `,
   Container: styled.div``,
   BackBtnContainer: styled.div`

--- a/src/components/layout/grid-layout/index.tsx
+++ b/src/components/layout/grid-layout/index.tsx
@@ -9,6 +9,8 @@ export default function GridLayout({ children }: Props) {
 
 const S = {
   Wrapper: styled.div`
+    padding-top: 100px;
+    height: 100%;
     background-size: 20px 20px;
     background-image: ${({ theme }) => `linear-gradient(to right, ${theme.colors.neutral.bg05} 1px, transparent 1px),
       linear-gradient(to bottom, ${theme.colors.neutral.bg05} 1px, transparent 1px);`};

--- a/src/components/layout/mobile-layout/index.tsx
+++ b/src/components/layout/mobile-layout/index.tsx
@@ -7,22 +7,53 @@ interface Props {
 
 export default function MobileLayout({ children }: Props) {
   return (
-    <S.Layout>
-      <S.LogoWrapper>
-        <HEADER_LAYOUT_LOGO />
-      </S.LogoWrapper>
-      {children}
-    </S.Layout>
+    <S.LayoutWrapper>
+      <S.Layout>
+        <S.LogoWrapper>
+          <HEADER_LAYOUT_LOGO />
+        </S.LogoWrapper>
+        {children}
+      </S.Layout>
+    </S.LayoutWrapper>
   );
 }
 
 const S = {
+  LayoutWrapper: styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    background-color: ${({ theme }) => theme.colors.neutral.bg05};
+    min-height: 100vh;
+  `,
   Layout: styled.div`
     max-width: 360px;
     margin: 0 auto;
+    width: 100%;
+    background-color: ${({ theme }) => theme.colors.white};
+
+    @media screen and (max-width: 768px) {
+      max-width: 100%;
+    }
   `,
   LogoWrapper: styled.div`
+    position: fixed;
+    top: 0;
+    width: 360px;
     height: 44px;
-    background-color: #cfd8db;
+    background-color: ${({ theme }) => theme.colors.neutral.bg10};
+    z-index: 1;
+
+    @media screen and (max-width: 768px) {
+      width: 100%;
+    }
+
+    svg {
+      width: 360px;
+
+      @media screen and (max-width: 768px) {
+        width: 100%;
+      }
+    }
   `,
 };


### PR DESCRIPTION
## 📑 제목
반응형 웹 고려

## 📎 관련 이슈
resolve #KB-81
  
## 💬 작업 내용
<img width="760" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/cfa496a5-a8e1-4acb-b622-4bd913159564">
<img width="320" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/695ea71f-270a-4e21-a13b-b5e2b9339b4d">


- 반응형 웹 고려하여 메모 스프링 적용
  우선 768px 기준으로 했습니다.
  screen < 768px ? 100%
- 메모 스프링, CHeader positon fix로 수정
 
## 🚧 PR 특이 사항
- 이거 먼저 merge 하고 그 다음 KB-80 PR 올리겠습니다!
- 다른 component도 반응형에 맞게 차차 수정하면 될 거 같습니다

## 🕰 실제 소요 시간
1h