### PR TITLE
[KB-77] 메뉴 추첨 페이지 화면 구성

### DIFF
--- a/public/image/Button/Main_Button_default.svg
+++ b/public/image/Button/Main_Button_default.svg
@@ -1,4 +1,4 @@
-<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="2" width="236" height="56" fill="#FFA202"/>
 <rect x="4" width="2" height="2" fill="#546E7A"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#546E7A"/>

--- a/public/image/Button/Main_Button_disabled.svg
+++ b/public/image/Button/Main_Button_disabled.svg
@@ -1,4 +1,4 @@
-<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="2" width="236" height="56" fill="#FFEDB3"/>
 <rect x="4" width="2" height="2" fill="#CFD8DB"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#CFD8DB"/>

--- a/public/image/Button/Main_Button_pressed.svg
+++ b/public/image/Button/Main_Button_pressed.svg
@@ -1,4 +1,4 @@
-<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="6" width="236" height="52" fill="#FFA202"/>
 <rect x="4" y="4" width="2" height="2" fill="#546E7A"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#546E7A"/>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,16 +8,22 @@ import * as S from './page.styled';
 import HomeIcon from '@/assets/logo/home.svg';
 import MypageIcon from '@/assets/logo/my-page.svg';
 import ReviewIcon from '@/assets/logo/review.svg';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 export default function Home() {
   const pathName = usePathname();
+  const router = useRouter();
 
   return (
     <>
       <CHeader title="맛셔너리" isLogo />
       <S.MainContent>
-        <CPickerButton title={'메뉴 고르기'} desc={'오늘은 어떤 음식을 먹을까?'} subject={'menu'} />
+        <CPickerButton
+          title={'메뉴 고르기'}
+          desc={'오늘은 어떤 음식을 먹을까?'}
+          subject={'menu'}
+          clickEvent={() => router.push('select-menu')}
+        />
         <CPickerButton title={'식당 고르기'} desc={'오늘은 어떤 식당에 가볼까?'} subject={'restaurant'} />
       </S.MainContent>
 

--- a/src/app/select-menu/page.tsx
+++ b/src/app/select-menu/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import IC_PIN2 from '@/assets/common/Pin2.svg';
+import IC_REFRESH from '@/assets/common/refresh_default.svg';
 import menu_set from '@/assets/data/menu_set.json';
+import MainButton from '@/components/Button/MainButton';
 import CHeader from '@/components/c-header';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -119,6 +121,20 @@ export default function SelectMenu() {
           })}
         </S.KeywordContainer>
       </S.Section>
+
+      <MainButton btnText="메뉴 추첨 시작" disabled={btnDisabled} style={{ maxWidth: 240, margin: '48px auto 0' }} />
+
+      <S.RefreshContainer
+        disabled={btnDisabled}
+        onClick={() => {
+          setSelectedCategory([]);
+          setSelectedKeyword([]);
+        }}
+      >
+        <IC_REFRESH />
+
+        <S.RefreshText>선택 초기화</S.RefreshText>
+      </S.RefreshContainer>
     </>
   );
 }

--- a/src/assets/common/refresh_default.svg
+++ b/src/assets/common/refresh_default.svg
@@ -1,0 +1,122 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="6" y="3" width="1" height="1" fill="#FED750"/>
+<rect x="6" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="6" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="6" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 6 15)" fill="#37474F"/>
+<rect x="5" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="5" y="3" width="1" height="1" fill="#FED750"/>
+<rect x="5" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="4" y="4" width="1" height="1" fill="#FED750"/>
+<rect x="5" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="5" y="11" width="1" height="1" fill="#FF7002"/>
+<rect x="4" y="11" width="1" height="1" fill="#FFA202"/>
+<rect x="4" y="10" width="1" height="1" fill="#FF7002"/>
+<rect x="3" y="10" width="1" height="1" fill="#FFA202"/>
+<rect x="3" y="9" width="1" height="1" fill="#FF7002"/>
+<rect x="3" y="8" width="1" height="1" fill="#FF7002"/>
+<rect x="3" y="7" width="1" height="1" fill="#FF7002"/>
+<rect x="3" y="6" width="1" height="1" fill="#FFA202"/>
+<rect x="3" y="5" width="1" height="1" fill="#FED750"/>
+<rect x="4" y="6" width="1" height="1" fill="#FFA202"/>
+<rect x="4" y="5" width="1" height="1" fill="#FFA202"/>
+<rect x="5" y="5" width="1" height="1" fill="#FFA202"/>
+<rect x="2" y="10" width="1" height="1" fill="#FFA202"/>
+<rect x="2" y="9" width="1" height="1" fill="#FFA202"/>
+<rect x="2" y="8" width="1" height="1" fill="#FFA202"/>
+<rect x="2" y="7" width="1" height="1" fill="#FFA202"/>
+<rect x="2" y="6" width="1" height="1" fill="#FED750"/>
+<rect x="3" y="11" width="1" height="1" fill="#FFA202"/>
+<rect x="4" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="5" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 5 15)" fill="#37474F"/>
+<rect x="4" y="3" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 4 14)" fill="#37474F"/>
+<rect x="3" y="4" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 3 13)" fill="#37474F"/>
+<rect x="2" y="5" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 2 12)" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 1 11)" fill="#37474F"/>
+<rect x="1" y="6" width="1" height="1" fill="#37474F"/>
+<rect x="1" y="7" width="1" height="1" fill="#37474F"/>
+<rect x="1" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="1" y="9" width="1" height="1" fill="#37474F"/>
+<rect x="7" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="7" y="3" width="1" height="1" fill="#FED750"/>
+<rect x="7" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="7" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="7" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 7 15)" fill="#37474F"/>
+<rect x="8" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="8" y="3" width="1" height="1" fill="#FED750"/>
+<rect x="8" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="8" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="8" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 8 15)" fill="#37474F"/>
+<rect x="9" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="9" y="3" width="1" height="1" fill="#FED750"/>
+<rect x="9" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="9" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="9" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 9 15)" fill="#37474F"/>
+<rect x="10" y="2" width="1" height="1" fill="#37474F"/>
+<rect x="10" y="3" width="1" height="1" fill="#FFA202"/>
+<rect x="10" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="4" width="1" height="1" fill="#FFA202"/>
+<rect x="10" y="5" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="5" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="6" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="7" width="1" height="1" fill="#FF7002"/>
+<rect x="10" y="7" width="1" height="1" fill="#FF7002"/>
+<rect x="12" y="5" width="1" height="1" fill="#FFA202"/>
+<rect x="12" y="6" width="1" height="1" fill="#FFA202"/>
+<rect x="12" y="7" width="1" height="1" fill="#FF7002"/>
+<rect x="13" y="5" width="1" height="1" fill="#FF7002"/>
+<rect x="13" y="6" width="1" height="1" fill="#FF7002"/>
+<rect x="13" y="7" width="1" height="1" fill="#FF7002"/>
+<rect x="13" y="4" width="1" height="1" fill="#FF7002"/>
+<rect x="10" y="12" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="12" width="1" height="1" fill="#FF7002"/>
+<rect x="10" y="11" width="1" height="1" fill="#FFA202"/>
+<rect x="11" y="11" width="1" height="1" fill="#FFA202"/>
+<rect x="12" y="11" width="1" height="1" fill="#FF7002"/>
+<rect x="10" y="13" width="1" height="1" fill="#FF7002"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 10 15)" fill="#37474F"/>
+<rect x="11" y="3" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 11 14)" fill="#37474F"/>
+<rect x="12" y="4" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 12 13)" fill="#37474F"/>
+<rect x="13" y="3" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="4" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="3" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="5" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="6" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="7" width="1" height="1" fill="#37474F"/>
+<rect x="14" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="13" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="12" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="11" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="10" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="9" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="9" y="7" width="1" height="1" fill="#37474F"/>
+<rect x="10" y="6" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 10 11)" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 11 11)" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 12 11)" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 13 11)" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 13 12)" fill="#37474F"/>
+<rect x="9" y="5" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 9 12)" fill="#37474F"/>
+<rect x="8" y="5" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 8 12)" fill="#37474F"/>
+<rect x="7" y="5" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 7 12)" fill="#37474F"/>
+<rect x="6" y="5" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 6 12)" fill="#37474F"/>
+<rect x="5" y="6" width="1" height="1" fill="#37474F"/>
+<rect width="1" height="1" transform="matrix(1 0 0 -1 5 11)" fill="#37474F"/>
+<rect x="4" y="7" width="1" height="1" fill="#37474F"/>
+<rect x="4" y="8" width="1" height="1" fill="#37474F"/>
+<rect x="4" y="9" width="1" height="1" fill="#37474F"/>
+</svg>

--- a/src/components/Button/MainButton/page.styled.ts
+++ b/src/components/Button/MainButton/page.styled.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const Button = styled.button`
   max-width: 360px;
   width: 100%;
+  height: 60px;
   aspect-ratio: 4;
   background: url('./image/Button/Main_Button_default.svg') center no-repeat;
   background-size: cover;

--- a/src/components/c-pickerButton/index.tsx
+++ b/src/components/c-pickerButton/index.tsx
@@ -6,12 +6,18 @@ interface Props {
   title: string;
   desc: string;
   subject: 'menu' | 'restaurant';
+  clickEvent?: () => void;
 }
 
-export default function CPickerButton({ title, desc, subject }: Props) {
+export default function CPickerButton({ title, desc, subject, clickEvent }: Props) {
   return (
     <>
-      <S.Button subject={subject}>
+      <S.Button
+        subject={subject}
+        onClick={() => {
+          if (clickEvent) clickEvent();
+        }}
+      >
         <HorizontalLayout subject={subject}>
           <S.Header></S.Header>
           <S.Content>


### PR DESCRIPTION
## 📑 제목
메뉴 추첨 페이지 화면 구성

## 📎 관련 이슈
resolve #KB-77
  
## 💬 작업 내용
<img width="341" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/ff5bd4c0-b811-4292-8632-a6a3edef9a59">
 
## 🚧 PR 특이 사항
-   음식 종류와 키워드 모두 한 개씩은 선택 해야 '메뉴 추첨 시작' 버튼과 '선택 초기화' 버튼이 활성화 됩니다.

## 🕰 실제 소요 시간
1h