### PR TITLE
[KB-96] 메뉴 추첨 결과 페이지 작업

### DIFF
--- a/public/image/Button/Main_Button_default.svg
+++ b/public/image/Button/Main_Button_default.svg
@@ -1,4 +1,4 @@
-<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="2" width="236" height="56" fill="#FFA202"/>
 <rect x="4" width="2" height="2" fill="#546E7A"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#546E7A"/>

--- a/public/image/Button/Main_Button_disabled.svg
+++ b/public/image/Button/Main_Button_disabled.svg
@@ -1,4 +1,4 @@
-<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="2" width="236" height="56" fill="#FFEDB3"/>
 <rect x="4" width="2" height="2" fill="#CFD8DB"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#CFD8DB"/>

--- a/public/image/Button/Main_Button_pressed.svg
+++ b/public/image/Button/Main_Button_pressed.svg
@@ -1,4 +1,4 @@
-<svg width="100%" height="60" viewBox="0 0 100% 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="2" y="6" width="236" height="52" fill="#FFA202"/>
 <rect x="4" y="4" width="2" height="2" fill="#546E7A"/>
 <rect width="2" height="2" transform="matrix(1 0 0 -1 4 60)" fill="#546E7A"/>

--- a/public/image/Menu/menu_korean.svg
+++ b/public/image/Menu/menu_korean.svg
@@ -1,4 +1,4 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="2.13333" height="2.13333" transform="matrix(-1 0 0 1 32 6.40002)" fill="black"/>
 <rect width="2.13333" height="2.13333" transform="matrix(-1 0 0 1 32 55.4667)" fill="black"/>
 <rect x="32" y="6.40002" width="2.13334" height="2.13333" fill="black"/>

--- a/src/app/select-menu/page.tsx
+++ b/src/app/select-menu/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import IC_PIN2 from '@/assets/common/Pin2.svg';
-import IC_REFRESH from '@/assets/common/refresh_default.svg';
 import menu_set from '@/assets/data/menu_set.json';
 import MainButton from '@/components/Button/MainButton';
+import RefreshButton from '@/components/Button/RefreshButton';
 import CHeader from '@/components/c-header';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -124,17 +124,14 @@ export default function SelectMenu() {
 
       <MainButton btnText="메뉴 추첨 시작" disabled={btnDisabled} style={{ maxWidth: 240, margin: '48px auto 0' }} />
 
-      <S.RefreshContainer
+      <RefreshButton
+        btnText="선택 초기화"
         disabled={btnDisabled}
         onClick={() => {
           setSelectedCategory([]);
           setSelectedKeyword([]);
         }}
-      >
-        <IC_REFRESH />
-
-        <S.RefreshText>선택 초기화</S.RefreshText>
-      </S.RefreshContainer>
+      />
     </>
   );
 }

--- a/src/app/select-menu/result/page.styled.ts
+++ b/src/app/select-menu/result/page.styled.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 20px 40px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const ResultTitle = styled.div`
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  margin-bottom: 16px;
+`;
+
+export const MemoTitle = styled.div`
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 4px;
+`;
+
+export const ButtonContainer = styled.div`
+  width: 100%;
+  margin-top: 20px;
+`;

--- a/src/app/select-menu/result/page.tsx
+++ b/src/app/select-menu/result/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import MainButton from '@/components/Button/MainButton';
+import RefreshButton from '@/components/Button/RefreshButton';
+import CHeader from '@/components/c-header';
+import CStickyMemo from '@/components/c-sticky-memo';
+import { useRouter } from 'next/navigation';
+import MENU_KOREAN from '../../../../public/image/Menu/menu_korean.svg';
+import * as S from './page.styled';
+
+export default function SelectMenuResult() {
+  const router = useRouter();
+
+  return (
+    <>
+      <CHeader isLogo isBackBtn title="맛셔너리" />
+
+      <S.Container>
+        <S.ResultTitle>오늘의 점심 메뉴는...</S.ResultTitle>
+
+        <CStickyMemo>
+          <S.MemoTitle>김치찌개!</S.MemoTitle>
+
+          <MENU_KOREAN width={160} height={160} />
+        </CStickyMemo>
+
+        <S.ButtonContainer>
+          <MainButton btnText="다시 선택하기" />
+
+          <RefreshButton btnText="조건 재설정" onClick={() => router.push('/select-menu')} />
+        </S.ButtonContainer>
+      </S.Container>
+    </>
+  );
+}

--- a/src/components/Button/MainButton/page.styled.ts
+++ b/src/components/Button/MainButton/page.styled.ts
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
 
 export const Button = styled.button`
-  max-width: 360px;
   width: 100%;
   height: 60px;
-  aspect-ratio: 4;
-  background: url('./image/Button/Main_Button_default.svg') center no-repeat;
-  background-size: cover;
+  background: url(/image/Button/Main_Button_default.svg) center no-repeat;
+  background-size: contain;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,10 +18,10 @@ export const Button = styled.button`
   &:disabled {
     color: ${({ theme }) => theme.colors.primary.y30};
     text-shadow: none;
-    background-image: url('./image/Button/Main_Button_disabled.svg');
+    background-image: url('/image/Button/Main_Button_disabled.svg');
   }
 
   &:enabled:active {
-    background-image: url('./image/Button/Main_Button_pressed.svg');
+    background-image: url('/image/Button/Main_Button_pressed.svg');
   }
 `;

--- a/src/components/Button/RefreshButton/index.tsx
+++ b/src/components/Button/RefreshButton/index.tsx
@@ -1,0 +1,17 @@
+import IC_REFRESH from '@/assets/common/refresh_default.svg';
+import { ButtonHTMLAttributes } from 'react';
+import * as S from './pagd.styled';
+
+interface RefreshButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  btnText: string;
+}
+
+export default function RefreshButton({ btnText, ...rest }: RefreshButtonProps) {
+  return (
+    <S.RefreshContainer {...rest}>
+      <IC_REFRESH />
+
+      <S.RefreshText>{btnText}</S.RefreshText>
+    </S.RefreshContainer>
+  );
+}

--- a/src/components/Button/RefreshButton/pagd.styled.ts
+++ b/src/components/Button/RefreshButton/pagd.styled.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const RefreshContainer = styled.button<{ disabled?: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  max-width: 166px;
+  margin: 24px auto 18px;
+  padding: 12px 32px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  opacity: ${({ disabled }) => (disabled ? '0.4' : 1)};
+`;
+
+export const RefreshText = styled.span`
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+`;

--- a/src/components/c-sticky-memo/index.tsx
+++ b/src/components/c-sticky-memo/index.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import * as S from './page.styled';
+
+interface CStickyMemoProps {
+  children: ReactNode;
+}
+
+export default function CStickyMemo({ children }: CStickyMemoProps) {
+  return (
+    <S.Container>
+      <S.Shadow />
+      <S.StickyMemoHeader />
+      <S.StickyMemo>{children}</S.StickyMemo>
+    </S.Container>
+  );
+}

--- a/src/components/c-sticky-memo/page.styled.ts
+++ b/src/components/c-sticky-memo/page.styled.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+`;
+
+export const StickyMemoHeader = styled.div`
+  width: 100%;
+  height: 20px;
+  background-color: ${({ theme }) => theme.colors.primary.y20};
+`;
+
+export const StickyMemo = styled.div`
+  width: 100%;
+  padding: 24px;
+  background-color: ${({ theme }) => theme.colors.primary.y10};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const Shadow = styled.div`
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.1);
+  height: 100%;
+  z-index: -1;
+`;


### PR DESCRIPTION
## 📑 제목
메뉴 추첨 결과 페이지 작업

## 📎 관련 이슈
resolve #KB-96
  
## 💬 작업 내용
<img width="242" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/1341fc24-a38a-42ae-9fe5-626b7169cabf">

- /select-menu/result 에서 확인 가능합니다.
- 메모지 같이 생긴 부분은 CStickyMemo 라는 컴포넌트를 만들어 작업했습니다.
- '조건 재설정' 부분은 메뉴 추첨 화면의 '선택 초기화' 버튼이 쓰여 RefreshButton 이라는 컴포넌트를 만들어 작업했습니다.
 
## 🚧 PR 특이 사항
- 작업 하다 보니 MainButton 컴포넌트를 수정해야 할 거 같아 같이 수정했습니다! (이미지 경로 등)
- 우선 메뉴 이미지는 카테고리의 이미지를 사용하였습니다. 나중에 메뉴 이미지들이 추가 되면 이미지는 교체하도록 하겠습니다.

## 🕰 실제 소요 시간
1h