### PR TITLE
[KB-164] 메인화면 UI 수정

### DIFF
--- a/src/app/example/components/ExampleHeader/page.styled.ts
+++ b/src/app/example/components/ExampleHeader/page.styled.ts
@@ -1,5 +1,5 @@
 'use client';
 
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.div``;

--- a/src/app/example/page.styled.ts
+++ b/src/app/example/page.styled.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 // 호진FIXME: 해당 부분을 객체로 관리하고 싶은데 객체로 관리할때는 에러가 발생하네요..
 export const Container = styled.div``;
 export const Box = styled.div``;

--- a/src/app/find-password/components/verify-auth-number/page.styled.ts
+++ b/src/app/find-password/components/verify-auth-number/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/find-password/components/verify-email/page.styled.ts
+++ b/src/app/find-password/components/verify-email/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/page.styled.ts
+++ b/src/app/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const MainContent = styled.main`
   padding: 40px;

--- a/src/app/sign-up/components/email-form/page.styled.ts
+++ b/src/app/sign-up/components/email-form/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/sign-up/components/opt-in-marketing/page.styled.ts
+++ b/src/app/sign-up/components/opt-in-marketing/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/sign-up/components/privacy-notice/page.styled.ts
+++ b/src/app/sign-up/components/privacy-notice/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/sign-up/components/terms/page.styled.ts
+++ b/src/app/sign-up/components/terms/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/app/sign-up/components/user-info-form/page.styled.ts
+++ b/src/app/sign-up/components/user-info-form/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 20px;

--- a/src/components/CheckBox/CheckBox2/page.styled.ts
+++ b/src/components/CheckBox/CheckBox2/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;

--- a/src/components/c-header/index.tsx
+++ b/src/components/c-header/index.tsx
@@ -19,7 +19,14 @@ export default function CHeader({ isLogo = false, isBackBtn = false, title }: Pr
           <S.BackBtnContainer $isBackBtn={isBackBtn}>
             {isBackBtn && <ISBACK_BTN onClick={() => router.back()} />}
           </S.BackBtnContainer>
-          <S.TitleContainer>
+          <S.TitleContainer
+            isLogo={isLogo}
+            onClick={() => {
+              if (isLogo) {
+                router.push('/');
+              }
+            }}
+          >
             {isLogo && <MAIN_LOGO />}
             <S.Title>{title}</S.Title>
           </S.TitleContainer>

--- a/src/components/c-header/page.styled.ts
+++ b/src/components/c-header/page.styled.ts
@@ -30,11 +30,12 @@ export const BackBtnContainer = styled.div<{ $isBackBtn?: boolean }>`
   align-items: center;
   justify-content: center;
 `;
-export const TitleContainer = styled.div`
+export const TitleContainer = styled.div<{ isLogo: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
   height: 24px;
+  cursor: ${({ isLogo }) => (isLogo ? 'pointer' : 'auto')};
 `;
 export const Title = styled.p`
   margin-left: 8px;

--- a/src/components/c-header/page.styled.ts
+++ b/src/components/c-header/page.styled.ts
@@ -1,9 +1,9 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   height: 56px;
   background-color: ${({ theme }) => theme.colors.white};
-  position: fixed;
+  position: absolute;
   top: 44px;
   width: 360px;
   z-index: 1;

--- a/src/components/c-nav-button/page.styled.ts
+++ b/src/components/c-nav-button/page.styled.ts
@@ -4,7 +4,7 @@ export const Button = styled.button<{ isActive: Boolean }>`
   width: 120px;
   height: 60px;
   background-color: ${({ theme, isActive }) => (isActive ? 'white' : theme.colors.neutral.bg05)};
-  border: 1px solid #ced9db;
+  border: ${({ isActive }) => (isActive ? 0 : 2)}px solid #ced9db;
 `;
 export const Icon = styled.div``;
 

--- a/src/components/c-nav-button/page.styled.ts
+++ b/src/components/c-nav-button/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Button = styled.button<{ isActive: Boolean }>`
   width: 120px;

--- a/src/components/c-pickerButton/page.styled.ts
+++ b/src/components/c-pickerButton/page.styled.ts
@@ -38,7 +38,9 @@ export const Header = styled.div`
   width: 100%;
   height: 20px;
 `;
-export const Content = styled.div``;
+export const Content = styled.div`
+  padding-top: 12px;
+`;
 export const Icon = styled.button`
   width: 72px;
   height: 72px;

--- a/src/components/c-pickerButton/page.styled.ts
+++ b/src/components/c-pickerButton/page.styled.ts
@@ -1,7 +1,7 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Button = styled.button<{ subject: 'menu' | 'restaurant' }>`
-  width: 280px;
+  width: 100%;
   box-shadow: 4px 4px 0px 0px rgba(0, 0, 0, 0.1);
   padding: 0px;
   background: repeating-linear-gradient(
@@ -35,7 +35,7 @@ export const Button = styled.button<{ subject: 'menu' | 'restaurant' }>`
   }
 `;
 export const Header = styled.div`
-  width: 280px;
+  width: 100%;
   height: 20px;
 `;
 export const Content = styled.div``;

--- a/src/components/c-pickerButton/page.styled.ts
+++ b/src/components/c-pickerButton/page.styled.ts
@@ -46,10 +46,10 @@ export const Icon = styled.button`
 export const Title = styled.p`
   font-size: 20px;
   text-shadow:
-    -1px 0 white,
-    0 1px white,
-    1px 0 white,
-    0 -1px white;
+    -2px 0 white,
+    0 2px white,
+    2px 0 white,
+    0 -2px white;
   font-weight: 400;
 `;
 export const Description = styled.p<{ subject: 'menu' | 'restaurant' }>`

--- a/src/components/layout/grid-layout/page.styled.ts
+++ b/src/components/layout/grid-layout/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding-top: 100px;

--- a/src/components/layout/horizontal-layout/page.styled.ts
+++ b/src/components/layout/horizontal-layout/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const Wrapper = styled.div<{ subject: 'menu' | 'restaurant' }>`
   background: ${({ theme, subject }) =>

--- a/src/components/layout/mobile-layout/page.styled.ts
+++ b/src/components/layout/mobile-layout/page.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 export const LayoutWrapper = styled.div`
   width: 100%;


### PR DESCRIPTION
## 📑 제목
메인화면 UI 수정

## 📎 관련 이슈
resolve #KB-164
  
## 💬 작업 내용
<img width="377" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/e516c1cc-acfd-43c7-8e59-e61b0a6b04fe">

- iPhone XR 등 너비값이 달라질 경우 메뉴 고르기 / 식당 고르기 부분이 중앙 정렬이 되지 않는 문제 해결
- 아이콘 윗 여백 추가
- 메뉴 고르기 / 식당 고르기 외곽선 2px로 수정
- 맛셔너리 로고 선택 시 메인 화면으로 이동
- 하단 탭바 메뉴 Active 상태에서 border-top 삭제
 
## 🚧 PR 특이 사항
- ssr className 오류 부분 수정을 위해 전체 `import { styled } from 'styled-components'` 을 `import styled from 'styled-components' `로 수정 ([참고](https://github.com/vercel/next.js/issues/46605#issuecomment-1639900755))


## 🕰 실제 소요 시간
1h