### PR TITLE
[KB-167] 메뉴 추첨 결과 화면 UI 수정

### DIFF
--- a/src/app/select-menu/result/page.styled.ts
+++ b/src/app/select-menu/result/page.styled.ts
@@ -15,12 +15,13 @@ export const ResultTitle = styled.div`
 `;
 
 export const MemoTitle = styled.div`
-  font-size: 32px;
+  font-size: 20px;
   font-weight: 700;
-  margin-bottom: 4px;
+  margin-bottom: 20px;
+  text-align: center;
 `;
 
 export const ButtonContainer = styled.div`
   width: 100%;
-  margin-top: 20px;
+  margin-top: 48px;
 `;


### PR DESCRIPTION
## 📑 제목
메뉴 추첨 결과 화면 UI 수정

## 📎 관련 이슈
resolve #KB-167
  
## 💬 작업 내용
<img width="440" alt="image" src="https://github.com/bside-4team/4team-client/assets/66504333/27ae4a46-e815-47aa-bfc6-eb2db8e993a1">


- 메뉴 텍스트 사이즈가 매우 커서 수정 필요. 다른 텍스트와 비교하여 상대적으로 많이 크며 가운데정렬 필요
메뉴명 긴 삼각김밥&컵라면의 경우 줄바꿈되어 나타나게 됨
- 텍스트와 메뉴 아이콘 사이 간격 추가
- 포스트잇 - 다시 선택하기 버튼 사이 간격 추가
 
## 🚧 PR 특이 사항
- 없습니다 

## 🕰 실제 소요 시간
0.1h